### PR TITLE
Fixed ACM query URL

### DIFF
--- a/biblatex_check.py
+++ b/biblatex_check.py
@@ -24,7 +24,7 @@ libraries = [("Scholar", "http://scholar.google.de/scholar?hl=en&q="),
              ("Google", "https://www.google.com/search?q="),
              ("DBLP", "http://dblp.org/search/index.php#query="),
              ("IEEE", "http://ieeexplore.ieee.org/search/searchresult.jsp?queryText="),
-             ("ACM", "http://dl.acm.org/results.cfm?within="),
+             ("ACM", "http://dl.acm.org/results.cfm?nquery="),
              ]
 
 


### PR DESCRIPTION
Fixed ACM query URL. It was nquery instead of within
