### PR TITLE
Fix NameError for requiredFieldsString

### DIFF
--- a/biblatex_check.py
+++ b/biblatex_check.py
@@ -175,15 +175,15 @@ for line in fIn:
             for fieldName, requiredFieldsType in requiredFields.items():
                 if fieldName == currentType.lower():
                     if isinstance(requiredFieldsType, str):
-                        currentrequiredFields = requiredFields[fieldName]
+                        currentrequiredField = requiredFields[fieldName]
 
                         # support for author/editor syntax
-                        typeFields = requiredFieldsString.split('/')
+                        typeFields = currentrequiredField.split('/')
 
                         # the required field is not found
                         if set(typeFields).isdisjoint(fields):
                             subproblems.append(
-                                "missing field '" + requiredFieldsString + "'")
+                                "missing field '" + currentrequiredField + "'")
                             counterMissingFields += 1
                     else:
                         currentrequiredFields = requiredFieldsType


### PR DESCRIPTION
Hello,

the following error occurs for WWW entries without the "online" property:

```shell
$ python biblatex_check.py -b bibliography.bib
WARNING: Aux file 'references.aux' doesn't exist -> not restricting entries
Traceback (most recent call last):
  File "biblatex_check.py", line 181, in <module>
    typeFields = requiredFieldsString.split('/')
NameError: name 'requiredFieldsString' is not defined
```

The PR fixes the error. I'm not 100% sure it is the correct solution from the checking standpoint...