### PR TITLE
add the default aux and output for the opotional -o -a options

### DIFF
--- a/biblatex_check.py
+++ b/biblatex_check.py
@@ -69,7 +69,7 @@ requiredFields = {"article": ["author", "title", "journaltitle/journal", "year/d
                   }
 
 ####################################################################
-
+import os
 import string
 import re
 import sys
@@ -137,24 +137,37 @@ if options.no_console:
 if options.htmlOutput:
     print("INFO: Will output HTML to '" + options.htmlOutput + "'"
         + (" and auto open in the default web browser" if options.view else ""))
+else:#output a default file if -o option is not provided
+    options.htmlOutput=options.bibFile+'.html'
 
 # Filter by reference ID's that are used
 usedIds = set()
 if options.auxFile:
     print("INFO: Filtering by references found in '" + options.auxFile + "'")
     try:
-        fInAux = open(options.auxFile, 'r', encoding="utf8")
-        for line in fInAux:
-            if line.startswith("\\citation"):
-                ids = line.split("{")[1].rstrip("} \n").split(", ")
-                for id in ids:
+        if os.path.exists(options.auxFile):
+            fInAux = open(options.auxFile, 'r', encoding="utf8")
+            for line in fInAux:
+                if line.startswith("\\citation"):
+                    ids = line.split("{")[1].rstrip("} \n").split(", ")
+                    for id in ids:
+                        if (id != ""):
+                            usedIds.add(id)
+            fInAux.close()
+        else:#check all entries in bib file if aux file is not exist
+            print('read bib file')
+            fInb = open(options.bibFile, 'r', encoding="utf8")
+            for line in fInb:
+                if line.startswith("@"):
+                    id = line.split("{")[1].split(',')[0]
                     if (id != ""):
                         usedIds.add(id)
-        fInAux.close()
+            fInb.close()
     except IOError as e:
         print ("WARNING: Aux file '" + options.auxFile +
                "' doesn't exist -> not restricting entries")
-
+	
+    
 # Go through and check all references
 completeEntry = ""
 currentId = ""


### PR DESCRIPTION
Sometimes we need to check all the entries in the bib file other than
the referenced entries in aux file, so we can add some code to deal for
the omitted aux file and omitted output file specifications.