### PR TITLE
Added check for invalid author format

### DIFF
--- a/biblatex_check.py
+++ b/biblatex_check.py
@@ -265,10 +265,22 @@ for (lineNumber, line) in enumerate(fIn):
                 # biblatex is not case sensitive
                 field = line.split("=")[0].strip().lower()
                 fields.append(field)
-                value = line.split("=")[1].strip("{} ,\n")
+                value = line.split("=")[1].strip(", \n").strip("{} \n")
                 if field == "author":
                     currentAuthor = filter(
                         lambda x: not (x in "\\\"{}"), value.split(" and ")[0])
+                    for author in value.split(" and "):
+                        comp = author.split(",")
+                        if len(comp) == 0:
+                            subproblems.append("too little name components for an author in field 'author'")
+                        elif len(comp) > 2:
+                            subproblems.append("too many name components for an author in field 'author'")
+                        elif len(comp) == 2:
+                            if comp[0].strip() == "":
+                                subproblems.append("last name of an author in field 'author' empty")
+                            if comp[1].strip() == "":
+                                subproblems.append("first name of an author in field 'author' empty")
+
                 if field == "citeulike-article-id":
                     currentArticleId = value
                 if field == "title":

--- a/tests/input.bib
+++ b/tests/input.bib
@@ -59,3 +59,29 @@
   institution={Carnegie Mellon University}
   year={1996},
 }
+
+% "article": ["author", "title", "journal", "year"]
+% wrong author
+@techreport{nistFIPS197Advanced2001,
+  title = {{{FIPS}} 197, {{Advanced Encryption Standard}} ({{AES}})},
+  author = {, NIST},
+  institution = {National Institute of Standards and Technology},
+  date = {2001-11-26},
+  pages = {51},
+  langid = {english}
+}
+
+% "report": ["author", "title", "date"]
+% 3 author components (should be 'lastname, firstname')
+@report{petersonObservationsModelingSeismic1993,
+  title = {Observations and Modeling of Seismic Background Noise},
+  author = {Peterson, Jon, R},
+  date = {1993},
+  institution = {{U.S. Geological Survey}},
+  doi = {10.3133/ofr93322},
+  url = {http://pubs.er.usgs.gov/publication/ofr93322},
+  urldate = {2020-12-30},
+  number = {93-322},
+  series = {Open-{{File Report}}},
+  type = {USGS Numbered Series}
+}


### PR DESCRIPTION
biber was crashing on the line:
 ` author = {, NIST},`
created check for empty author components