### PR TITLE
Explicitly rejoin filter list to a string

### DIFF
--- a/biblatex_check.py
+++ b/biblatex_check.py
@@ -389,7 +389,7 @@ def handleEntryField(lineNumber, line):
 
     # Checks per field type
     if fieldName == "author":
-        entryAuthor = filter(lambda x: not (x in '\\"{}'), fieldValue.split(" and ")[0])
+        entryAuthor = "".join(filter(lambda x: not (x in '\\"{}'), fieldValue.split(" and ")[0]))
         for author in fieldValue.split(" and "):
             comp = author.split(",")
             if len(comp) == 0:

--- a/tests/input.bib
+++ b/tests/input.bib
@@ -1,5 +1,5 @@
 % This file should fail with the commented errors
-% 14 errors expected
+% 15 errors expected
 
 % "misc": ["author/editor", "title", "year/date"]
 % year/date missing
@@ -95,4 +95,13 @@
   address={Address is an alias fro location},
   type = {Website},
   year = {2014},
+}
+
+% "book": ["author", "title", "year/date"],
+% Capitals handled, and no errors in author field
+% year/date field missing
+@book {hartshorne1977algebraic,
+  AUTHOR = {Hartshorne R},
+  TITLE = {Algebraic geometry},
+  NOTE = {Graduate Texts in Mathematics, No. 52},
 }


### PR DESCRIPTION
Fixes #54

Filter no longer casts to a string implicitly, now it's explicit.