### PR TITLE
Force conversion of 'map(' to list, fix w/python 3

### DIFF
--- a/biblatex_check.py
+++ b/biblatex_check.py
@@ -322,12 +322,12 @@ def handleEntryEnding(lineNumber, line):
         counterMissingCommas -= 1
 
     # Support for type aliases
-    entryFields = map(
+    entryFields = list(map(
         lambda typeName: fieldAliases.get(typeName)
         if typeName in fieldAliases
         else typeName,
         entryFields,
-    )
+    ))
 
     entryHTML += line + "<br />"
 


### PR DESCRIPTION
Otherwise I'm seeing errors like:

Traceback (most recent call last):
  File "./biblatex-check", line 476, in <module>
    handleEntryLine(bibLineNumber, bibLine)
  File "./biblatex-check", line 377, in handleEntryLine
    handleEntryField(lineNumber, line)
  File "./biblatex-check", line 388, in handleEntryField
    entryFields.append(fieldName)
AttributeError: 'map' object has no attribute 'append'