### PR TITLE
Fixed open in webbrowser

### DIFF
--- a/biblatex_check.py
+++ b/biblatex_check.py
@@ -776,9 +776,11 @@ $(document).ready(function(){
     html.close()
 
     if options.view:
+        import os
+        import pathlib
         import webbrowser
 
-        webbrowser.open(html.name)
+        webbrowser.open(pathlib.Path(os.path.abspath(html.name)).as_uri())
 
     print("SUCCESS: Report {} has been generated".format(options.htmlOutput))
 


### PR DESCRIPTION
Opening a generated HTML file in the default web browser did not work before, since the name of the file first needs to be converted to a `file:///` URL with the absolute path of the file. This is fixed by this pull request.